### PR TITLE
Minor changes to export to support EPSM a little better

### DIFF
--- a/FamiStudio/Source/UI/Common/ExportDialog.cs
+++ b/FamiStudio/Source/UI/Common/ExportDialog.cs
@@ -320,7 +320,7 @@ namespace FamiStudio
                     if (format == ExportFormat.FamiTone2Music && project.UsesAnyExpansionAudio)
                     {
                         page.AddLabel(null, "FamiTone2 does not support audio expansions.", true);
-                        canExportToSoundEngine = false;
+                        //canExportToSoundEngine = false;
                     }
                     else if (format == ExportFormat.FamiStudioMusic && project.UsesMultipleExpansionAudios)
                     {


### PR DESCRIPTION
Also has a minor workaround for an existing bug in FS master (commenting out the canExportToSoundEngine works around an issue preventing exporting FamiStudio music code when using an expansion)